### PR TITLE
Relax lockup creation signatures

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -20,7 +20,7 @@ pub enum PaladinLockupInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    /// 0. `[s]` Lockup authority.
+    /// 0. `[ ]` Lockup authority.
     /// 1. `[s]` Token owner.
     /// 2. `[w]` Depositor token account.
     /// 3. `[w]` Lockup account.
@@ -115,7 +115,7 @@ pub fn lockup(
         token_program_id,
     );
     let accounts = vec![
-        AccountMeta::new_readonly(*lockup_authority_address, true),
+        AccountMeta::new_readonly(*lockup_authority_address, false),
         AccountMeta::new_readonly(*token_owner_address, true),
         AccountMeta::new(*token_account_address, false),
         AccountMeta::new(*lockup_address, false),

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -44,11 +44,6 @@ fn process_lockup(
     let mint_info = next_account_info(accounts_iter)?;
     let token_program_info = next_account_info(accounts_iter)?;
 
-    // Ensure the lockup authority is a signer.
-    if !lockup_authority_info.is_signer {
-        return Err(ProgramError::MissingRequiredSignature);
-    }
-
     // Ensure the lockup account is owned by the Paladin Lockup program.
     if lockup_info.owner != program_id {
         return Err(ProgramError::InvalidAccountOwner);

--- a/program/tests/lockup.rs
+++ b/program/tests/lockup.rs
@@ -25,54 +25,6 @@ use {
 };
 
 #[tokio::test]
-async fn fail_lockup_authority_not_signer() {
-    let lockup_authority = Keypair::new();
-    let mint = Pubkey::new_unique();
-
-    let token_owner = Keypair::new();
-    let token_account = get_associated_token_address_with_program_id(
-        &token_owner.pubkey(),
-        &mint,
-        &spl_token_2022::id(),
-    );
-
-    let lockup = Pubkey::new_unique();
-
-    let mut context = setup().start_with_context().await;
-
-    let mut instruction = paladin_lockup_program::instruction::lockup(
-        &lockup_authority.pubkey(),
-        &token_owner.pubkey(),
-        &token_account,
-        &lockup,
-        &mint,
-        10_000,
-        10_000,
-        &spl_token_2022::id(),
-    );
-    instruction.accounts[0].is_signer = false; // Lockup authority is not a signer.
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &token_owner], // Missing lockup authority.
-        context.last_blockhash,
-    );
-
-    let err = context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap_err()
-        .unwrap();
-
-    assert_eq!(
-        err,
-        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
-    );
-}
-
-#[tokio::test]
 async fn fail_incorrect_lockup_owner() {
     let lockup_authority = Keypair::new();
     let mint = Pubkey::new_unique();
@@ -121,7 +73,7 @@ async fn fail_incorrect_lockup_owner() {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 
@@ -187,7 +139,7 @@ async fn fail_lockup_not_enough_space() {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 
@@ -261,7 +213,7 @@ async fn fail_lockup_already_initialized() {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 
@@ -329,7 +281,7 @@ async fn fail_incorrect_escrow_authority_address() {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 
@@ -400,7 +352,7 @@ async fn fail_incorrect_escrow_token_account_address() {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 
@@ -509,7 +461,7 @@ async fn success(amount: u64, period_seconds: u64) {
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&context.payer.pubkey()),
-        &[&context.payer, &lockup_authority, &token_owner],
+        &[&context.payer, &token_owner],
         context.last_blockhash,
     );
 


### PR DESCRIPTION
As briefly mentioned in #7, we maybe don't need the signature of the lockup
authority to _create_ the lockup, just to withdraw.

This PR relaxes that signature requirement for the instruction `Lockup`.