### PR TITLE
program: Make lockups perpetual, unlock and wait to withdraw

### DIFF
--- a/clients/js/src/generated/accounts/lockup.ts
+++ b/clients/js/src/generated/accounts/lockup.ts
@@ -17,8 +17,6 @@ import {
   getAddressEncoder,
   getArrayDecoder,
   getArrayEncoder,
-  getOptionDecoder,
-  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
   getU64Decoder,
@@ -35,22 +33,20 @@ import {
   type FetchAccountsConfig,
   type MaybeAccount,
   type MaybeEncodedAccount,
-  type Option,
-  type OptionOrNullable,
 } from '@solana/web3.js';
 import {
-  getNonZeroU64Decoder,
-  getNonZeroU64Encoder,
-  type NonZeroU64,
-  type NonZeroU64Args,
-} from '../types';
+  getNullableU64Decoder,
+  getNullableU64Encoder,
+  type NullableU64,
+  type NullableU64Args,
+} from '../../hooked';
 
 export type Lockup = {
   discriminator: Array<number>;
   amount: bigint;
   authority: Address;
   lockupStartTimestamp: bigint;
-  lockupEndTimestamp: Option<NonZeroU64>;
+  lockupEndTimestamp: NullableU64;
   mint: Address;
 };
 
@@ -59,7 +55,7 @@ export type LockupArgs = {
   amount: number | bigint;
   authority: Address;
   lockupStartTimestamp: number | bigint;
-  lockupEndTimestamp: OptionOrNullable<NonZeroU64Args>;
+  lockupEndTimestamp: NullableU64Args;
   mint: Address;
 };
 
@@ -69,7 +65,7 @@ export function getLockupEncoder(): Encoder<LockupArgs> {
     ['amount', getU64Encoder()],
     ['authority', getAddressEncoder()],
     ['lockupStartTimestamp', getU64Encoder()],
-    ['lockupEndTimestamp', getOptionEncoder(getNonZeroU64Encoder())],
+    ['lockupEndTimestamp', getNullableU64Encoder()],
     ['mint', getAddressEncoder()],
   ]);
 }
@@ -80,7 +76,7 @@ export function getLockupDecoder(): Decoder<Lockup> {
     ['amount', getU64Decoder()],
     ['authority', getAddressDecoder()],
     ['lockupStartTimestamp', getU64Decoder()],
-    ['lockupEndTimestamp', getOptionDecoder(getNonZeroU64Decoder())],
+    ['lockupEndTimestamp', getNullableU64Decoder()],
     ['mint', getAddressDecoder()],
   ]);
 }

--- a/clients/js/src/generated/accounts/lockup.ts
+++ b/clients/js/src/generated/accounts/lockup.ts
@@ -17,6 +17,8 @@ import {
   getAddressEncoder,
   getArrayDecoder,
   getArrayEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
   getU64Decoder,
@@ -33,14 +35,22 @@ import {
   type FetchAccountsConfig,
   type MaybeAccount,
   type MaybeEncodedAccount,
+  type Option,
+  type OptionOrNullable,
 } from '@solana/web3.js';
+import {
+  getNonZeroU64Decoder,
+  getNonZeroU64Encoder,
+  type NonZeroU64,
+  type NonZeroU64Args,
+} from '../types';
 
 export type Lockup = {
   discriminator: Array<number>;
   amount: bigint;
   authority: Address;
   lockupStartTimestamp: bigint;
-  lockupEndTimestamp: bigint;
+  lockupEndTimestamp: Option<NonZeroU64>;
   mint: Address;
 };
 
@@ -49,7 +59,7 @@ export type LockupArgs = {
   amount: number | bigint;
   authority: Address;
   lockupStartTimestamp: number | bigint;
-  lockupEndTimestamp: number | bigint;
+  lockupEndTimestamp: OptionOrNullable<NonZeroU64Args>;
   mint: Address;
 };
 
@@ -59,7 +69,7 @@ export function getLockupEncoder(): Encoder<LockupArgs> {
     ['amount', getU64Encoder()],
     ['authority', getAddressEncoder()],
     ['lockupStartTimestamp', getU64Encoder()],
-    ['lockupEndTimestamp', getU64Encoder()],
+    ['lockupEndTimestamp', getOptionEncoder(getNonZeroU64Encoder())],
     ['mint', getAddressEncoder()],
   ]);
 }
@@ -70,7 +80,7 @@ export function getLockupDecoder(): Decoder<Lockup> {
     ['amount', getU64Decoder()],
     ['authority', getAddressDecoder()],
     ['lockupStartTimestamp', getU64Decoder()],
-    ['lockupEndTimestamp', getU64Decoder()],
+    ['lockupEndTimestamp', getOptionDecoder(getNonZeroU64Decoder())],
     ['mint', getAddressDecoder()],
   ]);
 }
@@ -130,8 +140,4 @@ export async function fetchAllMaybeLockup(
 ): Promise<MaybeAccount<Lockup>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => decodeLockup(maybeAccount));
-}
-
-export function getLockupSize(): number {
-  return 96;
 }

--- a/clients/js/src/generated/instructions/lockup.ts
+++ b/clients/js/src/generated/instructions/lockup.ts
@@ -78,23 +78,15 @@ export type LockupInstruction<
     ]
   >;
 
-export type LockupInstructionData = {
-  discriminator: number;
-  amount: bigint;
-  periodSeconds: bigint;
-};
+export type LockupInstructionData = { discriminator: number; amount: bigint };
 
-export type LockupInstructionDataArgs = {
-  amount: number | bigint;
-  periodSeconds: number | bigint;
-};
+export type LockupInstructionDataArgs = { amount: number | bigint };
 
 export function getLockupInstructionDataEncoder(): Encoder<LockupInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
-      ['periodSeconds', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 0 })
   );
@@ -104,7 +96,6 @@ export function getLockupInstructionDataDecoder(): Decoder<LockupInstructionData
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['amount', getU64Decoder()],
-    ['periodSeconds', getU64Decoder()],
   ]);
 }
 
@@ -145,7 +136,6 @@ export type LockupInput<
   /** Token program */
   tokenProgram?: Address<TAccountTokenProgram>;
   amount: LockupInstructionDataArgs['amount'];
-  periodSeconds: LockupInstructionDataArgs['periodSeconds'];
 };
 
 export function getLockupInstruction<

--- a/clients/js/src/hooked/index.ts
+++ b/clients/js/src/hooked/index.ts
@@ -1,0 +1,1 @@
+export * from './nullableU64';

--- a/clients/js/src/hooked/nullableU64.ts
+++ b/clients/js/src/hooked/nullableU64.ts
@@ -1,0 +1,35 @@
+import { combineCodec, createDecoder, createEncoder } from '@solana/web3.js';
+import { getU64Decoder, getU64Encoder } from '@solana/web3.js';
+
+export type NullableU64 = number | bigint | null;
+export type NullableU64Args = NullableU64;
+
+const DEFAULT_VALUE = BigInt(0);
+
+export const getNullableU64Encoder = () =>
+  createEncoder<NullableU64>({
+    fixedSize: 8,
+    write(value, bytes, offset) {
+      if (value === null) {
+        bytes.set(getU64Encoder().encode(DEFAULT_VALUE), offset);
+      } else {
+        bytes.set(getU64Encoder().encode(value), offset);
+      }
+      return offset + 8;
+    },
+  });
+
+export const getNullableU64Decoder = () =>
+  createDecoder<NullableU64>({
+    fixedSize: 32,
+    read(bytes, offset) {
+      if (getU64Decoder().decode(bytes, offset) === DEFAULT_VALUE) {
+        return [null, offset + 8];
+      } else {
+        return [getU64Decoder().decode(bytes, offset), offset + 8];
+      }
+    },
+  });
+
+export const getNullableU64Codec = () =>
+  combineCodec(getNullableU64Encoder(), getNullableU64Decoder());

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,1 +1,2 @@
 export * from './generated';
+export * from './hooked';

--- a/clients/rust/src/generated/accounts/lockup.rs
+++ b/clients/rust/src/generated/accounts/lockup.rs
@@ -5,6 +5,7 @@
 //! <https://github.com/kinobi-so/kinobi>
 
 use {
+    crate::generated::types::NonZeroU64,
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::pubkey::Pubkey,
 };
@@ -20,7 +21,7 @@ pub struct Lockup {
     )]
     pub authority: Pubkey,
     pub lockup_start_timestamp: u64,
-    pub lockup_end_timestamp: u64,
+    pub lockup_end_timestamp: Option<NonZeroU64>,
     #[cfg_attr(
         feature = "serde",
         serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
@@ -29,8 +30,6 @@ pub struct Lockup {
 }
 
 impl Lockup {
-    pub const LEN: usize = 96;
-
     #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;

--- a/clients/rust/src/generated/accounts/lockup.rs
+++ b/clients/rust/src/generated/accounts/lockup.rs
@@ -5,7 +5,7 @@
 //! <https://github.com/kinobi-so/kinobi>
 
 use {
-    crate::generated::types::NonZeroU64,
+    crate::hooked::NullableU64,
     borsh::{BorshDeserialize, BorshSerialize},
     solana_program::pubkey::Pubkey,
 };
@@ -21,7 +21,7 @@ pub struct Lockup {
     )]
     pub authority: Pubkey,
     pub lockup_start_timestamp: u64,
-    pub lockup_end_timestamp: Option<NonZeroU64>,
+    pub lockup_end_timestamp: NullableU64,
     #[cfg_attr(
         feature = "serde",
         serde(with = "serde_with::As::<serde_with::DisplayFromStr>")

--- a/clients/rust/src/generated/instructions/lockup.rs
+++ b/clients/rust/src/generated/instructions/lockup.rs
@@ -106,7 +106,6 @@ impl Default for LockupInstructionData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LockupInstructionArgs {
     pub amount: u64,
-    pub period_seconds: u64,
 }
 
 /// Instruction builder for `Lockup`.
@@ -133,7 +132,6 @@ pub struct LockupBuilder {
     token_mint: Option<solana_program::pubkey::Pubkey>,
     token_program: Option<solana_program::pubkey::Pubkey>,
     amount: Option<u64>,
-    period_seconds: Option<u64>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
@@ -207,11 +205,6 @@ impl LockupBuilder {
         self.amount = Some(amount);
         self
     }
-    #[inline(always)]
-    pub fn period_seconds(&mut self, period_seconds: u64) -> &mut Self {
-        self.period_seconds = Some(period_seconds);
-        self
-    }
     /// Add an aditional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
@@ -250,10 +243,6 @@ impl LockupBuilder {
         };
         let args = LockupInstructionArgs {
             amount: self.amount.clone().expect("amount is not set"),
-            period_seconds: self
-                .period_seconds
-                .clone()
-                .expect("period_seconds is not set"),
         };
 
         accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
@@ -457,7 +446,6 @@ impl<'a, 'b> LockupCpiBuilder<'a, 'b> {
             token_mint: None,
             token_program: None,
             amount: None,
-            period_seconds: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -539,11 +527,6 @@ impl<'a, 'b> LockupCpiBuilder<'a, 'b> {
         self.instruction.amount = Some(amount);
         self
     }
-    #[inline(always)]
-    pub fn period_seconds(&mut self, period_seconds: u64) -> &mut Self {
-        self.instruction.period_seconds = Some(period_seconds);
-        self
-    }
     /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
@@ -588,11 +571,6 @@ impl<'a, 'b> LockupCpiBuilder<'a, 'b> {
     ) -> solana_program::entrypoint::ProgramResult {
         let args = LockupInstructionArgs {
             amount: self.instruction.amount.clone().expect("amount is not set"),
-            period_seconds: self
-                .instruction
-                .period_seconds
-                .clone()
-                .expect("period_seconds is not set"),
         };
         let instruction = LockupCpi {
             __program: self.instruction.__program,
@@ -654,7 +632,6 @@ struct LockupCpiBuilderInstruction<'a, 'b> {
     token_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
-    period_seconds: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(
         &'b solana_program::account_info::AccountInfo<'a>,

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -1,0 +1,3 @@
+mod nullable_u64;
+
+pub use nullable_u64::*;

--- a/clients/rust/src/hooked/nullable_u64.rs
+++ b/clients/rust/src/hooked/nullable_u64.rs
@@ -1,0 +1,27 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NullableU64(u64);
+
+impl NullableU64 {
+    pub fn value(&self) -> Option<u64> {
+        if self.0 == u64::default() {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+}
+
+impl From<Option<u64>> for NullableU64 {
+    fn from(value: Option<u64>) -> Self {
+        Self(value.unwrap_or_default())
+    }
+}
+
+impl From<u64> for NullableU64 {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,3 +1,7 @@
 mod generated;
+mod hooked;
 
-pub use generated::{programs::PALADIN_LOCKUP_PROGRAM_ID as ID, *};
+pub use {
+    generated::{programs::PALADIN_LOCKUP_PROGRAM_ID as ID, *},
+    hooked::*,
+};

--- a/program/idl.json
+++ b/program/idl.json
@@ -74,10 +74,6 @@
         {
           "name": "amount",
           "type": "u64"
-        },
-        {
-          "name": "periodSeconds",
-          "type": "u64"
         }
       ],
       "discriminant": {
@@ -215,7 +211,11 @@
           },
           {
             "name": "lockupEndTimestamp",
-            "type": "u64"
+            "type": {
+              "option": {
+                "defined": "NonZeroU64"
+              }
+            }
           },
           {
             "name": "mint",

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -14,3 +14,5 @@ pub mod processor;
 pub mod state;
 
 solana_program::declare_id!("Dbf7u6x15DhjMrBMunY3XoRWdByrCCt2dbyoPrCXN6SQ");
+
+pub const LOCKUP_COOLDOWN_SECONDS: u64 = 30 * 60; // 30 minutes

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -3,6 +3,7 @@ use {
     shank::ShankAccount,
     solana_program::pubkey::Pubkey,
     spl_discriminator::SplDiscriminate,
+    std::num::NonZeroU64,
 };
 
 /// The seed prefix (`"escrow_authority"`) in bytes used to derive the address
@@ -41,7 +42,7 @@ pub struct Lockup {
     /// The start of the lockup period.
     pub lockup_start_timestamp: u64,
     /// The end of the lockup period.
-    pub lockup_end_timestamp: u64,
+    pub lockup_end_timestamp: Option<NonZeroU64>,
     /// The address of the mint this lockup supports.
     pub mint: Pubkey,
 }
@@ -52,7 +53,6 @@ impl Lockup {
         amount: u64,
         authority: &Pubkey,
         lockup_start_timestamp: u64,
-        lockup_end_timestamp: u64,
         mint: &Pubkey,
     ) -> Self {
         Self {
@@ -60,7 +60,7 @@ impl Lockup {
             amount,
             authority: *authority,
             lockup_start_timestamp,
-            lockup_end_timestamp,
+            lockup_end_timestamp: None,
             mint: *mint,
         }
     }

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -10,7 +10,7 @@ use {
         state::{get_escrow_authority_address, Lockup},
         LOCKUP_COOLDOWN_SECONDS,
     },
-    setup::{setup, setup_mint, setup_token_account},
+    setup::{add_seconds_to_clock, setup, setup_mint, setup_token_account},
     solana_program_test::*,
     solana_sdk::{
         clock::Clock,
@@ -214,13 +214,7 @@ async fn test_e2e() {
     // Warp the clock 30 seconds.
     // Alice can't withdraw until the period ends.
     {
-        let mut clock = context
-            .banks_client
-            .get_sysvar::<Clock>()
-            .await
-            .expect("get_sysvar");
-        clock.unix_timestamp = clock.unix_timestamp.saturating_add(30);
-        context.set_sysvar(&clock);
+        add_seconds_to_clock(&mut context, 30).await;
 
         send_transaction_with_expected_err(
             &mut context,
@@ -257,15 +251,7 @@ async fn test_e2e() {
     // Warp the clock 30 more minutes.
     // Alice can now withdraw.
     {
-        let mut clock = context
-            .banks_client
-            .get_sysvar::<Clock>()
-            .await
-            .expect("get_sysvar");
-        clock.unix_timestamp = clock
-            .unix_timestamp
-            .saturating_add(LOCKUP_COOLDOWN_SECONDS as i64);
-        context.set_sysvar(&clock);
+        add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
 
         send_transaction(
             &mut context,

--- a/program/tests/e2e.rs
+++ b/program/tests/e2e.rs
@@ -8,6 +8,7 @@ use {
     paladin_lockup_program::{
         error::PaladinLockupError,
         state::{get_escrow_authority_address, Lockup},
+        LOCKUP_COOLDOWN_SECONDS,
     },
     setup::{setup, setup_mint, setup_token_account},
     solana_program_test::*,
@@ -153,7 +154,6 @@ async fn test_e2e() {
     // Create a lockup for Alice.
     let alice_lockup = Keypair::new();
     let alice_lockup_amount = 1_000;
-    let alice_lockup_period_seconds = 60;
     {
         let clock = context
             .banks_client
@@ -181,7 +181,6 @@ async fn test_e2e() {
                     &alice_lockup.pubkey(),
                     &mint,
                     alice_lockup_amount,
-                    alice_lockup_period_seconds,
                     &spl_token_2022::id(),
                 ),
             ],
@@ -190,7 +189,6 @@ async fn test_e2e() {
         .await;
 
         let expected_lockup_start = clock.unix_timestamp as u64;
-        let expected_lockup_end = expected_lockup_start.saturating_add(alice_lockup_period_seconds);
 
         // Validate the lockup was created and tokens were transferred to the escrow.
         check_lockup_state(
@@ -200,7 +198,6 @@ async fn test_e2e() {
                 alice_lockup_amount,
                 &alice.pubkey(),
                 expected_lockup_start,
-                expected_lockup_end,
                 &mint,
             ),
         )
@@ -244,7 +241,20 @@ async fn test_e2e() {
         .await;
     }
 
-    // Warp the clock 30 more seconds.
+    // Unlock the lockup
+    {
+        send_transaction(
+            &mut context,
+            &[paladin_lockup_program::instruction::unlock(
+                &alice.pubkey(),
+                &alice_lockup.pubkey(),
+            )],
+            &[&payer, &alice],
+        )
+        .await;
+    }
+
+    // Warp the clock 30 more minutes.
     // Alice can now withdraw.
     {
         let mut clock = context
@@ -252,7 +262,9 @@ async fn test_e2e() {
             .get_sysvar::<Clock>()
             .await
             .expect("get_sysvar");
-        clock.unix_timestamp = clock.unix_timestamp.saturating_add(30);
+        clock.unix_timestamp = clock
+            .unix_timestamp
+            .saturating_add(LOCKUP_COOLDOWN_SECONDS as i64);
         context.set_sysvar(&clock);
 
         send_transaction(
@@ -280,168 +292,6 @@ async fn test_e2e() {
             &mut context,
             &alice_token_account,
             alice_token_account_starting_token_balance,
-        )
-        .await;
-        check_token_account_balance(&mut context, &escrow_token_account, 0).await;
-    }
-
-    // Create a lockup for Bob.
-    let bob_lockup = Keypair::new();
-    let bob_lockup_amount = 2_000;
-    let bob_lockup_period_seconds = 120;
-    {
-        let clock = context
-            .banks_client
-            .get_sysvar::<Clock>()
-            .await
-            .expect("get_sysvar");
-
-        let rent = context.banks_client.get_rent().await.expect("get_rent");
-        let space = std::mem::size_of::<Lockup>();
-
-        send_transaction(
-            &mut context,
-            &[
-                system_instruction::transfer(
-                    &payer.pubkey(),
-                    &bob_lockup.pubkey(),
-                    rent.minimum_balance(space),
-                ),
-                system_instruction::allocate(&bob_lockup.pubkey(), space as u64),
-                system_instruction::assign(&bob_lockup.pubkey(), &paladin_lockup_program::id()),
-                paladin_lockup_program::instruction::lockup(
-                    &bob.pubkey(),
-                    &bob.pubkey(),
-                    &bob_token_account,
-                    &bob_lockup.pubkey(),
-                    &mint,
-                    bob_lockup_amount,
-                    bob_lockup_period_seconds,
-                    &spl_token_2022::id(),
-                ),
-            ],
-            &[&payer, &bob, &bob_lockup],
-        )
-        .await;
-
-        let expected_lockup_start = clock.unix_timestamp as u64;
-        let expected_lockup_end = expected_lockup_start.saturating_add(bob_lockup_period_seconds);
-
-        // Validate the lockup was created and tokens were transferred to the escrow.
-        check_lockup_state(
-            &mut context,
-            &bob_lockup.pubkey(),
-            &Lockup::new(
-                bob_lockup_amount,
-                &bob.pubkey(),
-                expected_lockup_start,
-                expected_lockup_end,
-                &mint,
-            ),
-        )
-        .await;
-        check_token_account_balance(
-            &mut context,
-            &bob_token_account,
-            bob_token_account_starting_token_balance.saturating_sub(bob_lockup_amount),
-        )
-        .await;
-        check_token_account_balance(&mut context, &escrow_token_account, bob_lockup_amount).await;
-    }
-
-    // Warp the clock 60 seconds.
-    // Bob can't withdraw until the period ends.
-    {
-        let mut clock = context
-            .banks_client
-            .get_sysvar::<Clock>()
-            .await
-            .expect("get_sysvar");
-        clock.unix_timestamp = clock.unix_timestamp.saturating_add(60);
-        context.set_sysvar(&clock);
-
-        send_transaction_with_expected_err(
-            &mut context,
-            &[paladin_lockup_program::instruction::withdraw(
-                &bob.pubkey(),
-                &bob.pubkey(),
-                &bob_token_account,
-                &bob_lockup.pubkey(),
-                &mint,
-                &spl_token_2022::id(),
-            )],
-            &[&payer, &bob],
-            TransactionError::InstructionError(
-                0,
-                InstructionError::Custom(PaladinLockupError::LockupActive as u32),
-            ),
-        )
-        .await;
-    }
-
-    // Bob unlocks the tokens.
-    {
-        let clock = context
-            .banks_client
-            .get_sysvar::<Clock>()
-            .await
-            .expect("get_sysvar");
-
-        send_transaction(
-            &mut context,
-            &[paladin_lockup_program::instruction::unlock(
-                &bob.pubkey(),
-                &bob_lockup.pubkey(),
-            )],
-            &[&payer, &bob],
-        )
-        .await;
-
-        let expected_lockup_start = (clock.unix_timestamp as u64).saturating_sub(60);
-        let expected_lockup_end = clock.unix_timestamp as u64; // Now.
-
-        // Validate the lockup was unlocked.
-        check_lockup_state(
-            &mut context,
-            &bob_lockup.pubkey(),
-            &Lockup::new(
-                bob_lockup_amount,
-                &bob.pubkey(),
-                expected_lockup_start,
-                expected_lockup_end,
-                &mint,
-            ),
-        )
-        .await;
-    }
-
-    // Bob can now withdraw tokens.
-    {
-        send_transaction(
-            &mut context,
-            &[paladin_lockup_program::instruction::withdraw(
-                &bob.pubkey(),
-                &bob.pubkey(),
-                &bob_token_account,
-                &bob_lockup.pubkey(),
-                &mint,
-                &spl_token_2022::id(),
-            )],
-            &[&payer, &bob],
-        )
-        .await;
-
-        // Validate the lockup was closed and tokens were transferred back to Bob.
-        assert!(context
-            .banks_client
-            .get_account(bob_lockup.pubkey())
-            .await
-            .expect("get_account")
-            .is_none());
-        check_token_account_balance(
-            &mut context,
-            &bob_token_account,
-            bob_token_account_starting_token_balance,
         )
         .await;
         check_token_account_balance(&mut context, &escrow_token_account, 0).await;

--- a/program/tests/lockup.rs
+++ b/program/tests/lockup.rs
@@ -21,7 +21,7 @@ use {
     spl_associated_token_account::get_associated_token_address_with_program_id,
     spl_discriminator::SplDiscriminate,
     spl_token_2022::{extension::StateWithExtensions, state::Account as TokenAccount},
-    test_case::test_matrix,
+    test_case::test_case,
 };
 
 #[tokio::test]
@@ -65,7 +65,6 @@ async fn fail_incorrect_lockup_owner() {
         &token_account,
         &lockup,
         &mint,
-        10_000,
         10_000,
         &spl_token_2022::id(),
     );
@@ -131,7 +130,6 @@ async fn fail_lockup_not_enough_space() {
         &token_account,
         &lockup,
         &mint,
-        10_000,
         10_000,
         &spl_token_2022::id(),
     );
@@ -206,7 +204,6 @@ async fn fail_lockup_already_initialized() {
         &lockup,
         &mint,
         10_000,
-        10_000,
         &spl_token_2022::id(),
     );
 
@@ -272,7 +269,6 @@ async fn fail_incorrect_escrow_authority_address() {
         &token_account,
         &lockup,
         &mint,
-        10_000,
         10_000,
         &spl_token_2022::id(),
     );
@@ -344,7 +340,6 @@ async fn fail_incorrect_escrow_token_account_address() {
         &lockup,
         &mint,
         10_000,
-        10_000,
         &spl_token_2022::id(),
     );
     instruction.accounts[5].pubkey = Pubkey::new_unique(); // Incorrect escrow token account address.
@@ -390,12 +385,11 @@ async fn check_token_account_balance(
     assert_eq!(actual_amount, check_amount);
 }
 
-#[test_matrix(
-    (10_000, 100_000, 1_000_000),
-    (30, 1_000, 5_000_000)
-)]
+#[test_case(1)]
+#[test_case(1_000_000_000)]
+#[test_case(1_000_000_000_000_000)]
 #[tokio::test]
-async fn success(amount: u64, period_seconds: u64) {
+async fn success(amount: u64) {
     let lockup_authority = Keypair::new();
     let mint = Pubkey::new_unique();
 
@@ -454,7 +448,6 @@ async fn success(amount: u64, period_seconds: u64) {
         &lockup,
         &mint,
         amount,
-        period_seconds,
         &spl_token_2022::id(),
     );
 
@@ -487,7 +480,6 @@ async fn success(amount: u64, period_seconds: u64) {
             amount,
             &lockup_authority.pubkey(),
             clock.unix_timestamp as u64,
-            (clock.unix_timestamp as u64).saturating_add(period_seconds),
             &mint,
         )
     );

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -141,12 +141,12 @@ pub async fn setup_lockup(
     );
 }
 
-pub async fn set_clock(context: &mut ProgramTestContext, timestamp: i64) {
+pub async fn add_seconds_to_clock(context: &mut ProgramTestContext, seconds: u64) {
     let mut clock = context
         .banks_client
         .get_sysvar::<Clock>()
         .await
         .expect("get_sysvar");
-    clock.unix_timestamp = timestamp;
+    clock.unix_timestamp = clock.unix_timestamp.saturating_add(seconds as i64);
     context.set_sysvar(&clock);
 }

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -6,6 +6,7 @@ use {
     solana_program_test::*,
     solana_sdk::{
         account::{Account, AccountSharedData},
+        clock::Clock,
         program_option::COption,
         pubkey::Pubkey,
         system_program,
@@ -14,6 +15,7 @@ use {
         extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut},
         state::{Account as TokenAccount, AccountState, Mint},
     },
+    std::num::NonZeroU64,
 };
 
 pub fn setup() -> ProgramTest {
@@ -118,16 +120,11 @@ pub async fn setup_lockup(
     authority: &Pubkey,
     amount: u64,
     lockup_start_timestamp: u64,
-    lockup_end_timestamp: u64,
+    lockup_end_timestamp: Option<NonZeroU64>,
     mint_address: &Pubkey,
 ) {
-    let state = Lockup::new(
-        amount,
-        authority,
-        lockup_start_timestamp,
-        lockup_end_timestamp,
-        mint_address,
-    );
+    let mut state = Lockup::new(amount, authority, lockup_start_timestamp, mint_address);
+    state.lockup_end_timestamp = lockup_end_timestamp;
     let data = bytemuck::bytes_of(&state).to_vec();
 
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -142,4 +139,14 @@ pub async fn setup_lockup(
             ..Account::default()
         }),
     );
+}
+
+pub async fn set_clock(context: &mut ProgramTestContext, timestamp: i64) {
+    let mut clock = context
+        .banks_client
+        .get_sysvar::<Clock>()
+        .await
+        .expect("get_sysvar");
+    clock.unix_timestamp = timestamp;
+    context.set_sysvar(&clock);
 }

--- a/program/tests/unlock.rs
+++ b/program/tests/unlock.rs
@@ -139,7 +139,7 @@ async fn fail_incorrect_lockup_authority() {
         &Pubkey::new_unique(), // Incorrect authority.
         10_000,
         10_000,
-        10_000,
+        None,
         &Pubkey::new_unique(),
     )
     .await;
@@ -175,7 +175,6 @@ async fn success() {
 
     let clock = context.banks_client.get_sysvar::<Clock>().await.unwrap();
     let start = clock.unix_timestamp as u64;
-    let end = clock.unix_timestamp.saturating_add(10_000) as u64;
 
     setup_lockup(
         &mut context,
@@ -183,7 +182,7 @@ async fn success() {
         &authority.pubkey(),
         10_000, // Amount (unused here).
         start,
-        end,
+        None,
         &Pubkey::new_unique(),
     )
     .await;
@@ -211,6 +210,5 @@ async fn success() {
         .unwrap()
         .unwrap();
     let state = bytemuck::from_bytes::<Lockup>(&lockup_account.data);
-    assert_eq!(state.lockup_end_timestamp, start); // Unlocked in current
-                                                   // timestamp.
+    assert_eq!(state.lockup_end_timestamp.unwrap().get(), start);
 }

--- a/program/tests/withdraw.rs
+++ b/program/tests/withdraw.rs
@@ -8,7 +8,7 @@ use {
         state::{get_escrow_authority_address, Lockup},
         LOCKUP_COOLDOWN_SECONDS,
     },
-    setup::{set_clock, setup, setup_lockup, setup_mint, setup_token_account},
+    setup::{add_seconds_to_clock, setup, setup_lockup, setup_mint, setup_token_account},
     solana_program_test::*,
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -293,11 +293,7 @@ async fn fail_incorrect_escrow_authority_address() {
         &mint,
     )
     .await;
-    set_clock(
-        &mut context,
-        clock.unix_timestamp + LOCKUP_COOLDOWN_SECONDS as i64,
-    )
-    .await;
+    add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
 
     let mut instruction = paladin_lockup_program::instruction::withdraw(
         &authority.pubkey(),
@@ -367,11 +363,7 @@ async fn fail_incorrect_escrow_token_account_address() {
         &mint,
     )
     .await;
-    set_clock(
-        &mut context,
-        clock.unix_timestamp + LOCKUP_COOLDOWN_SECONDS as i64,
-    )
-    .await;
+    add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
 
     let mut instruction = paladin_lockup_program::instruction::withdraw(
         &authority.pubkey(),
@@ -510,11 +502,7 @@ async fn fail_incorrect_lockup_authority() {
         &mint,
     )
     .await;
-    set_clock(
-        &mut context,
-        clock.unix_timestamp + LOCKUP_COOLDOWN_SECONDS as i64,
-    )
-    .await;
+    add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
 
     let instruction = paladin_lockup_program::instruction::withdraw(
         &authority.pubkey(),
@@ -580,11 +568,7 @@ async fn fail_incorrect_mint() {
         &Pubkey::new_unique(), // Incorrect mint.
     )
     .await;
-    set_clock(
-        &mut context,
-        clock.unix_timestamp + LOCKUP_COOLDOWN_SECONDS as i64,
-    )
-    .await;
+    add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
 
     let instruction = paladin_lockup_program::instruction::withdraw(
         &authority.pubkey(),
@@ -664,11 +648,7 @@ async fn success() {
         &mint,
     )
     .await;
-    set_clock(
-        &mut context,
-        clock.unix_timestamp + LOCKUP_COOLDOWN_SECONDS as i64,
-    )
-    .await;
+    add_seconds_to_clock(&mut context, LOCKUP_COOLDOWN_SECONDS).await;
     setup_token_account(
         &mut context,
         &token_account,

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -30,10 +30,27 @@ kinobi.update(
   })
 );
 
+// Add missing types from the IDL.
+kinobi.update(
+  k.bottomUpTransformerVisitor([
+    {
+      // Option<NonZeroU64> -> NullableU64
+      select: "[structFieldTypeNode]lockupEndTimestamp",
+      transform: (node) => {
+        k.assertIsNode(node, "structFieldTypeNode");
+        return {
+          ...node,
+          type: k.definedTypeLinkNode("nullableU64", "hooked"),
+        };
+      },
+    },
+  ])
+);
+
 // Render JavaScript.
 const jsClient = path.join(__dirname, "..", "clients", "js");
 kinobi.accept(
-  renderJavaScriptVisitor(path.join(jsClient, "src", "generated"), { 
+  renderJavaScriptVisitor(path.join(jsClient, "src", "generated"), {
     prettier: require(path.join(jsClient, ".prettierrc.json"))
   })
 );


### PR DESCRIPTION
#### Problem

Addressing the last point from https://github.com/paladin-bladesmith/lockup-program/pull/5#discussion_r1684716526 -- lockups should be perpetual. When someone unlocks, they then need to wait the global cooldown of 30 minutes before they can withdraw.

#### Solution

Implement that logic. The concept is to set the end timestamp during unlock, and then they need to wait unlock + 30 minutes to withdraw.

While going through this, I removed the "bob" half of the e2e test, since manual unlocks are now required to eventually withdraw.

cc @buffalojoec for visibility, no need to do anything though!