### PR TITLE
Program: Unlock: Ensure lockup is not already unlocked

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -23,4 +23,7 @@ pub enum PaladinLockupError {
     /// Lockup is still active.
     #[error("Lockup is still active.")]
     LockupActive,
+    /// Lockup already unlocked.
+    #[error("Lockup already unlocked.")]
+    LockupAlreadyUnlocked,
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -150,6 +150,11 @@ fn process_unlock(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResul
         return Err(ProgramError::IncorrectAuthority);
     }
 
+    // Ensure the lockup account has not already been unlocked.
+    if state.lockup_end_timestamp.is_some() {
+        return Err(PaladinLockupError::LockupAlreadyUnlocked.into());
+    }
+
     // Get the timestamp from the clock sysvar, and use it to set the end
     // timestamp of the lockup, effectively unlocking the funds.
     let clock = <Clock as Sysvar>::get()?;


### PR DESCRIPTION
#### Problem
Currently, the program's `Unlock` instruction can be invoked repeatedly to continuously reset the lockup end timestamp. This isn't really an attack vector, since it has to be the lockup's authority who invokes it, but best not to allow the timer to continuously reset for any reason.

Once unlocked, the cooldown starts and shouldn't be interrupted.

#### Summary of Changes
Add a check to see if the lockup was already unlocked before unlocking, and fail if it was.