### PR TITLE
Lockup: Add metadata pubkey

### DIFF
--- a/clients/js/src/generated/accounts/lockup.ts
+++ b/clients/js/src/generated/accounts/lockup.ts
@@ -48,6 +48,7 @@ export type Lockup = {
   lockupStartTimestamp: bigint;
   lockupEndTimestamp: NullableU64;
   mint: Address;
+  metadata: Address;
 };
 
 export type LockupArgs = {
@@ -57,6 +58,7 @@ export type LockupArgs = {
   lockupStartTimestamp: number | bigint;
   lockupEndTimestamp: NullableU64Args;
   mint: Address;
+  metadata: Address;
 };
 
 export function getLockupEncoder(): Encoder<LockupArgs> {
@@ -67,6 +69,7 @@ export function getLockupEncoder(): Encoder<LockupArgs> {
     ['lockupStartTimestamp', getU64Encoder()],
     ['lockupEndTimestamp', getNullableU64Encoder()],
     ['mint', getAddressEncoder()],
+    ['metadata', getAddressEncoder()],
   ]);
 }
 
@@ -78,6 +81,7 @@ export function getLockupDecoder(): Decoder<Lockup> {
     ['lockupStartTimestamp', getU64Decoder()],
     ['lockupEndTimestamp', getNullableU64Decoder()],
     ['mint', getAddressDecoder()],
+    ['metadata', getAddressDecoder()],
   ]);
 }
 

--- a/clients/rust/src/generated/accounts/lockup.rs
+++ b/clients/rust/src/generated/accounts/lockup.rs
@@ -27,6 +27,11 @@ pub struct Lockup {
         serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
     )]
     pub mint: Pubkey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
+    pub metadata: Pubkey,
 }
 
 impl Lockup {

--- a/program/idl.json
+++ b/program/idl.json
@@ -220,6 +220,10 @@
           {
             "name": "mint",
             "type": "publicKey"
+          },
+          {
+            "name": "metadata",
+            "type": "publicKey"
           }
         ]
       }

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -45,6 +45,8 @@ pub struct Lockup {
     pub lockup_end_timestamp: Option<NonZeroU64>,
     /// The address of the mint this lockup supports.
     pub mint: Pubkey,
+    /// Address of any additional metadata (stored in another account).
+    pub metadata: Pubkey,
 }
 
 impl Lockup {
@@ -62,6 +64,7 @@ impl Lockup {
             lockup_start_timestamp,
             lockup_end_timestamp: None,
             mint: *mint,
+            metadata: Pubkey::default(),
         }
     }
 }


### PR DESCRIPTION
Adds a metadata pubkey to the lockup account state layout.